### PR TITLE
Added modal to show error in avatar size

### DIFF
--- a/components/soci-avatar-uploader.js
+++ b/components/soci-avatar-uploader.js
@@ -253,6 +253,7 @@ export default class SociFileDrop extends SociComponent {
     reader.addEventListener('loadend', ()=>{
       if(Math.min(preview.naturalWidth, preview.naturalHeight) < this._MINIMUMSIZE){
         this.log("File too small. Avatars must be a minimum of 240px on both sides.", "error")
+        document.querySelector("#avatar-size-modal")?.activate()
         return 0
       }
       this.toggleAttribute('cropping', true)

--- a/pages/admin/settings.pug
+++ b/pages/admin/settings.pug
@@ -1,5 +1,8 @@
 #admin-settings-container.container
   script(src="/pages/admin/settings.js")
+  soci-modal(title="Image too small" id="avatar-size-modal")
+    .modal-body
+      p Avatars must be a minimum of 240px on both sides.
   .blocks
     .block.avatar(load-order="primary")
       h2 Avatar


### PR DESCRIPTION
Got around to adding a simple modal to communicate the error.

![image](https://github.com/jjcm/soci-frontend/assets/55542353/868e6d30-44de-4dcd-a044-94e3723aa11e)


The size check is also only client side, meaning it is possible to upload any size with something like this:
`$("soci-avatar-uploader")._MINIMUMSIZE = 0 )`

Not sure if that's a problem or not.